### PR TITLE
Add optional dependencies to OSS plugin

### DIFF
--- a/buildSrc/src/main/groovy/com/it/ibm/stellantis/OssConventionsExtension.groovy
+++ b/buildSrc/src/main/groovy/com/it/ibm/stellantis/OssConventionsExtension.groovy
@@ -1,0 +1,12 @@
+package com.it.ibm.stellantis
+
+class OssConventionsExtension {
+    /** Abilita l'uso di spring-boot-starter-webflux */
+    boolean webflux = false
+
+    /** Abilita la dipendenza org.postgresql:postgresql */
+    boolean postgresql = false
+
+    /** Abilita la dipendenza org.glassfish.jersey.core:jersey-client */
+    boolean jerseyClient = false
+}

--- a/buildSrc/src/main/groovy/com/it/ibm/stellantis/OssConventionsPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/it/ibm/stellantis/OssConventionsPlugin.groovy
@@ -2,6 +2,14 @@ package com.it.ibm.stellantis
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import com.it.ibm.stellantis.OssConventionsExtension
+
+/**
+ * Plugin Gradle che definisce le dipendenze di base del progetto OSS. Alcune
+ * dipendenze opzionali possono essere abilitate tramite l'estensione
+ * {@link OssConventionsExtension} o le proprietà Gradle «oss.webflux»,
+ * «oss.postgresql» e «oss.jerseyClient».
+ */
 
 class OssConventionsPlugin implements Plugin<Project> {
     @Override
@@ -14,7 +22,10 @@ class OssConventionsPlugin implements Plugin<Project> {
             mavenCentral()
         }
 
-        // Dipendenze
+        // Estensione per abilitare le dipendenze opzionali
+        def extension = project.extensions.create('ossConventions', OssConventionsExtension)
+
+        // Dipendenze di base
         project.dependencies {
             add("implementation", "com.fasterxml.jackson.core:jackson-databind:2.14.2")
             add("implementation", "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.14.2")
@@ -22,25 +33,40 @@ class OssConventionsPlugin implements Plugin<Project> {
             add("implementation", "com.fasterxml.jackson.module:jackson-module-parameter-names:2.14.2")
             add("implementation", "com.fasterxml.jackson.core:jackson-core:2.14.2")
             add("implementation", "com.fasterxml.jackson.core:jackson-annotations:2.14.2")
-            
+
             add("implementation", "org.openapitools:jackson-databind-nullable:0.2.6")
-            
+
 
             add("implementation", "org.apache.logging.log4j:log4j-core:2.20.0")
             add("implementation", "org.apache.logging.log4j:log4j-api:2.20.0")
 
-            add("implementation", "org.postgresql:postgresql:42.6.0")
             add("implementation", "com.oracle.database.jdbc:ojdbc8:23.2.0.0")
 
             add("implementation", "javax.persistence:javax.persistence-api:2.2")
             add("implementation", "org.hibernate:hibernate-core:5.6.15.Final")
 
-            add("implementation", "org.glassfish.jersey.core:jersey-client:3.0.10")
-
             add("implementation", platform("org.springframework.boot:spring-boot-dependencies:2.7.18"))
             add("implementation", "org.springframework.boot:spring-boot-starter")
             add("implementation", "org.springframework.boot:spring-boot-starter-data-jpa")
-            add("implementation", "org.springframework.boot:spring-boot-starter-webflux")
+        }
+
+        // Dipendenze opzionali abilitate tramite estensione o proprietà Gradle
+        project.afterEvaluate {
+            def enableWebflux = extension.webflux || project.findProperty('oss.webflux')?.toString()?.toBoolean()
+            def enablePostgresql = extension.postgresql || project.findProperty('oss.postgresql')?.toString()?.toBoolean()
+            def enableJerseyClient = extension.jerseyClient || project.findProperty('oss.jerseyClient')?.toString()?.toBoolean()
+
+            project.dependencies {
+                if (enablePostgresql) {
+                    add('implementation', 'org.postgresql:postgresql:42.6.0')
+                }
+                if (enableJerseyClient) {
+                    add('implementation', 'org.glassfish.jersey.core:jersey-client:3.0.10')
+                }
+                if (enableWebflux) {
+                    add('implementation', 'org.springframework.boot:spring-boot-starter-webflux')
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add an `OssConventionsExtension` to configure optional deps
- update `OssConventionsPlugin` so that WebFlux, PostgreSQL and Jersey
  are added only if enabled via the extension or Gradle properties

## Testing
- `gradle build` *(fails: Cannot find a Java installation matching toolchain J9)*

------
https://chatgpt.com/codex/tasks/task_e_6881d6125e8c832dab09cb52c605192a