### PR TITLE
Enable log4j2 logging

### DIFF
--- a/buildSrc/src/main/groovy/com/it/ibm/stellantis/OssConventionsPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/it/ibm/stellantis/OssConventionsPlugin.groovy
@@ -28,6 +28,7 @@ class OssConventionsPlugin implements Plugin<Project> {
 
             add("implementation", "org.apache.logging.log4j:log4j-core:2.20.0")
             add("implementation", "org.apache.logging.log4j:log4j-api:2.20.0")
+            add("implementation", "org.apache.logging.log4j:log4j-jul:2.20.0")
 
             add("implementation", "org.postgresql:postgresql:42.6.0")
             add("implementation", "com.oracle.database.jdbc:ojdbc8:23.2.0.0")
@@ -38,9 +39,17 @@ class OssConventionsPlugin implements Plugin<Project> {
             add("implementation", "org.glassfish.jersey.core:jersey-client:3.0.10")
 
             add("implementation", platform("org.springframework.boot:spring-boot-dependencies:2.7.18"))
-            add("implementation", "org.springframework.boot:spring-boot-starter")
-            add("implementation", "org.springframework.boot:spring-boot-starter-data-jpa")
-            add("implementation", "org.springframework.boot:spring-boot-starter-webflux")
+            add("implementation", "org.springframework.boot:spring-boot-starter-log4j2")
+
+            add("implementation", "org.springframework.boot:spring-boot-starter") {
+                exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+            }
+            add("implementation", "org.springframework.boot:spring-boot-starter-data-jpa") {
+                exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+            }
+            add("implementation", "org.springframework.boot:spring-boot-starter-webflux") {
+                exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+            }
         }
     }
 }

--- a/custofleet/src/main/java/com/it/ibm/custofleet/CustofleetApplication.java
+++ b/custofleet/src/main/java/com/it/ibm/custofleet/CustofleetApplication.java
@@ -1,6 +1,7 @@
 package com.it.ibm.custofleet;
 
-import java.util.logging.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -11,7 +12,7 @@ import com.it.ibm.custofleet.service.VinExtractorService;
 @SpringBootApplication
 public class CustofleetApplication {
 
-    private static final Logger logger = Logger.getLogger(CustofleetApplication.class.getName());
+    private static final Logger logger = LogManager.getLogger(CustofleetApplication.class);
 
     public static void main(String[] args) {
         SpringApplication app = new SpringApplication(CustofleetApplication.class);

--- a/custofleet/src/main/java/com/it/ibm/custofleet/service/VinExtractorService.java
+++ b/custofleet/src/main/java/com/it/ibm/custofleet/service/VinExtractorService.java
@@ -1,7 +1,8 @@
 package com.it.ibm.custofleet.service;
 
 import java.util.List;
-import java.util.logging.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
@@ -17,7 +18,7 @@ import com.it.ibm.custofleet.repository.Taekt017Repository;
 @Service
 public class VinExtractorService {
 
-    private static final Logger logger = Logger.getLogger(VinExtractorService.class.getName());
+    private static final Logger logger = LogManager.getLogger(VinExtractorService.class);
 
     @Value("${custofleet.batch.size:100}")
     private int batchSize;


### PR DESCRIPTION
## Summary
- configure Boot starters to use Log4j2
- add bridging for Java Util Logging
- update CustofleetApplication and VinExtractorService to use Log4j2

## Testing
- `gradle build -x test` *(fails: Cannot find a Java installation matching {implementation=J9})*

------
https://chatgpt.com/codex/tasks/task_e_6881d70d46bc832d80a79d9f816bbc20